### PR TITLE
Added searchTweets and getTweetById

### DIFF
--- a/StormTwitter.class.php
+++ b/StormTwitter.class.php
@@ -81,6 +81,39 @@ class StormTwitter {
     
   }
   
+  function searchTweets($count = 20, $options = false) {
+
+    if ($count > 20) $count = 20;
+    if ($count < 1) $count = 1;
+
+    $default_options = array('trim_user'=>true, 'exclude_replies'=>true, 'include_rts'=>false);
+
+    if ($options === false || !is_array($options)) {
+      $options = $default_options;
+    } else {
+      $options = array_merge($default_options, $options);
+    }
+
+    $result = $this->checkValidCache("SEARCH",$options);
+
+    error_log($result);
+    if ($result !== false) {
+      return $this->cropTweets($result,$count);
+    }
+    //If we're here, we need to load.
+    $result = $this->oauthSearchTweets($options);
+    if (isset($result['errors'])) {
+      if (is_array($results) && isset($result['errors'][0]) && isset($result['errors'][0]['message'])) {
+        $last_error = $result['errors'][0]['message'];
+      } else {
+        $last_error = $result['errors'];
+      }
+      return array('error'=>'Twitter said: '.$last_error);
+    } else {
+      return $this->cropTweets($result,$count);
+    }
+  }
+  
   private function cropTweets($result,$count) {
    if(!empty($result)){
       return array_slice($result, 0, $count); 
@@ -176,8 +209,41 @@ class StormTwitter {
         $this->st_last_error = $last_error;
       }
     }
+  }
+  
+  private function oauthSearchTweets($options){
+    $key = $this->defaults['key'];
+    $secret = $this->defaults['secret'];
+    $token = $this->defaults['token'];
+    $token_secret = $this->defaults['token_secret'];
+    $cachename = "SEARCH-".$this->getOptionsHash($options);
+    $options = array_merge($options, array('count' => 20));
+    if (empty($key)) return array('error'=>'Missing Consumer Key - Check Settings');
+    if (empty($secret)) return array('error'=>'Missing Consumer Secret - Check Settings');
+    if (empty($token)) return array('error'=>'Missing Access Token - Check Settings');
+    if (empty($token_secret)) return array('error'=>'Missing Access Token Secret - Check Settings');
+    
+    $connection = new TwitterOAuth($key, $secret, $token, $token_secret);
+    $result = $connection->get('search/tweets', $options);
+    
+    if (is_file($this->getCacheLocation())) {
+      $cache = json_decode(file_get_contents($this->getCacheLocation()),true);
+    }
+    
+    if (!isset($result['errors'])) {
+      $cache[$cachename]['time'] = time();
+      $cache[$cachename]['tweets'] = $result;
+      $file = $this->getCacheLocation();
+      file_put_contents($file,json_encode($cache));
+    } else {
+      if (is_array($results) && isset($result['errors'][0]) && isset($result['errors'][0]['message'])) {
+        $last_error = '['.date('r').'] Twitter error: '.$result['errors'][0]['message'];
+        $this->st_last_error = $last_error;
+      } else {
+        $last_error = '['.date('r').'] Twitter returned an invalid response. It is probably down.';
+        $this->st_last_error = $last_error;
+      }
+    }
     
     return $result;
-  
-  }
-}
+  }}

--- a/twitter-feed-for-developers.php
+++ b/twitter-feed-for-developers.php
@@ -41,3 +41,8 @@ function getTweets($username = false, $count = 20, $options = false) {
 function searchTweets($count = 20, $options = false) {
   return requestTweets('searchTweets', array($count, $options));
 }
+
+/* implement getTweetById */
+function getTweetById($id) {
+   return requestTweets('getTweetById', array($id));
+}

--- a/twitter-feed-for-developers.php
+++ b/twitter-feed-for-developers.php
@@ -13,9 +13,9 @@ Author URI: http://www.stormconsultancy.co.uk
 require('StormTwitter.class.php');
 require('twitter-feed-for-developers-settings.php');
 
-/* implement getTweets */
-function getTweets($username = false, $count = 20, $options = false) {
-
+/* setup tweet request */
+function requestTweets($method, $args) {
+    
   $config['key'] = get_option('tdf_consumer_key');
   $config['secret'] = get_option('tdf_consumer_secret');
   $config['token'] = get_option('tdf_access_token');
@@ -26,8 +26,18 @@ function getTweets($username = false, $count = 20, $options = false) {
   $config['directory'] = plugin_dir_path(__FILE__);
   
   $obj = new StormTwitter($config);
-  $res = $obj->getTweets($username, $count, $options);
+  $res = call_user_func_array(array($obj, $method), $args);
+  
   update_option('tdf_last_error',$obj->st_last_error);
   return $res;
-  
+}
+
+/* implement getTweets */
+function getTweets($username = false, $count = 20, $options = false) {  
+  return requestTweets('getTweets', array($username, $count, $options));
+}
+
+/* implement searchTweets */
+function searchTweets($count = 20, $options = false) {
+  return requestTweets('searchTweets', array($count, $options));
 }


### PR DESCRIPTION
Added in the ability to use the `search/tweets` and the `statuses/show/:id` endpoints. Optimized the method calls in `twitter-feed-for-developers.php` to reduce code duplication. `StormTwitter.class.php` could use the same thing, but I didn't have a chance to optimize that yet. 